### PR TITLE
Keycloak configurable sms abuse treshold

### DIFF
--- a/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-sms-otp-config.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-sms-otp-config.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayWide=false; section>
+<@layout.registrationLayout displayInfo=true; section>
     <#if section = "header">
         ${msg("configSms2Fa")}
     <#elseif section = "form">

--- a/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-sms-otp.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-sms-otp.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayWide=false; section>
+<@layout.registrationLayout displayInfo=true; section>
     <#if section = "header">
         ${msg("authCodePhoneNumber")}
     <#elseif section = "form">

--- a/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-update-phone-number.ftl
+++ b/keycloak-phone-provider.resources/src/main/resources/theme-resources/templates/login-update-phone-number.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayWide=false; section>
+<@layout.registrationLayout displayInfo=true; section>
     <#if section = "header">
         ${msg("updatePhoneNumber")}
     <#elseif section = "form">

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/forms/RegistrationPhoneAsUserNameCreation.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/authentication/forms/RegistrationPhoneAsUserNameCreation.java
@@ -157,7 +157,7 @@ public class RegistrationPhoneAsUserNameCreation implements FormActionFactory, F
         user.setEnabled(true);
 
         context.getAuthenticationSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, username);
-        AttributeFormDataProcessor.process(formData, context.getRealm(), user);
+        AttributeFormDataProcessor.process(formData);
         context.setUser(user);
         context.getEvent().user(user);
         context.getEvent().success();

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/rest/VerificationCodeResource.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/rest/VerificationCodeResource.java
@@ -22,7 +22,7 @@ public class VerificationCodeResource extends TokenCodeResource {
 
     VerificationCodeResource(KeycloakSession session) {
         super(session, TokenCodeType.VERIFY);
-        this.auth = new AppAuthManager().authenticateBearerToken(session, session.getContext().getRealm());
+        this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
     }
 
     private TokenCodeService getTokenCodeService() {

--- a/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/spi/impl/TokenCodeServiceProviderFactoryImpl.java
+++ b/keycloak-phone-provider/src/main/java/cc/coopersoft/keycloak/phone/providers/spi/impl/TokenCodeServiceProviderFactoryImpl.java
@@ -8,13 +8,16 @@ import org.keycloak.models.KeycloakSessionFactory;
 
 public class TokenCodeServiceProviderFactoryImpl implements TokenCodeServiceProviderFactory {
 
+    private Config.Scope config;
+
     @Override
     public TokenCodeService create(KeycloakSession session) {
-        return new TokenCodeServiceImpl(session);
+        return new TokenCodeServiceImpl(session, config);
     }
 
     @Override
-    public void init(Config.Scope scope) {
+    public void init(Config.Scope config) {
+        this.config = config;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.keycloak>11.0.3</version.keycloak>
+        <version.keycloak>12.0.4</version.keycloak>
 
         <docker.image.name>coopersoft/keycloak-phone</docker.image.name>
 


### PR DESCRIPTION
This PR adds the option abuse_hourly_threshold to configure the maximum amount of sms per hour.
There was already a default, hardcoded, threshold of 3. 